### PR TITLE
Fixed typo causing error during startup

### DIFF
--- a/sfintegration/startup.sh
+++ b/sfintegration/startup.sh
@@ -23,7 +23,7 @@ else
     config_file=config.json
 fi
 
-if [ ${Fabric_NodeName} == ""]
+if [ ${Fabric_NodeName} == "" ]
 then
     Fabric_NodeName="standalone"
 fi


### PR DESCRIPTION
```
./startup.sh: line 26: [: _Primary_2: unary operator expected
```