### PR TITLE
Release docker image for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: csharp
 services:
   - docker
@@ -11,7 +12,13 @@ branches:
   - sridmad
 install:
   - export DOTNET_CLI_TELEMETRY_OPTOUT=1
+  - sudo curl -sSL https://get.docker.com/ | sh
 before_script:
   - chmod a+x ./deploycontainer.sh
+  - mkdir -p ~/.docker/cli-plugins
+  - wget -O - https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+  - chmod a+x ~/.docker/cli-plugins/docker-buildx
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker buildx create --use --name mybuilder
 script:
   - ./deploycontainer.sh $TRAVIS_BRANCH $TRAVIS_COMMIT $DOCKER_USERNAME $DOCKER_PASSWORD $TRAVIS_TAG

--- a/deploycontainer.sh
+++ b/deploycontainer.sh
@@ -28,19 +28,9 @@ dotnet publish -c $config sfintegration -f netcoreapp2.1 -r ubuntu.16.04-x64 --s
 # Pull the previous image to speed up image generation
 docker pull $BRANCH/service-fabric-reverse-proxy:latest
 
-# Build the Docker images
+# Login to Docker Hub
+docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
 echo docker build -t $BRANCH/service-fabric-reverse-proxy:$TAG --label GIT_COMMIT=$GIT_COMMIT ./sfintegration/bin/$config/netcoreapp2.1/ubuntu.16.04-x64/publish/.
-docker build -t $BRANCH/service-fabric-reverse-proxy:$TAG --label GIT_COMMIT=$GIT_COMMIT ./sfintegration/bin/$config/netcoreapp2.1/ubuntu.16.04-x64/publish/.
-echo docker tag $BRANCH/service-fabric-reverse-proxy:$TAG $BRANCH/service-fabric-reverse-proxy:xenial-$TAG
-docker tag $BRANCH/service-fabric-reverse-proxy:$TAG $BRANCH/service-fabric-reverse-proxy:xenial-$TAG
-echo docker tag $BRANCH/service-fabric-reverse-proxy:$TAG $BRANCH/service-fabric-reverse-proxy:latest
-docker tag $BRANCH/service-fabric-reverse-proxy:$TAG $BRANCH/service-fabric-reverse-proxy:latest
 
-# Login to Docker Hub and upload images
-echo $DOCKER_PASSWORD | docker login -u="$DOCKER_USERNAME" --password-stdin
-echo docker push $BRANCH/service-fabric-reverse-proxy:$TAG
-docker push $BRANCH/service-fabric-reverse-proxy:$TAG
-echo docker push $BRANCH/service-fabric-reverse-proxy:xenial-$TAG
-docker push $BRANCH/service-fabric-reverse-proxy:xenial-$TAG
-echo docker push $BRANCH/service-fabric-reverse-proxy:latest
-docker push $BRANCH/service-fabric-reverse-proxy:latest
+# Build and upload images
+docker buildx build --push --platform linux/amd64,linux/arm64 -t $BRANCH/service-fabric-reverse-proxy:$TAG -t $BRANCH/service-fabric-reverse-proxy:xenial-$TAG -t $BRANCH/service-fabric-reverse-proxy:latest --label GIT_COMMIT=$GIT_COMMIT ./sfintegration/bin/$config/netcoreapp2.1/ubuntu.16.04-x64/publish/.

--- a/sfintegration/Dockerfile
+++ b/sfintegration/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:866a4bab8c1e7809e26409ac9636843070b2f61c
+FROM envoyproxy/envoy:v1.17-latest
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
The following files have been modified:

Added buildx in **travis.yml** to build and push the image for both the platforms to dockerhub.

In the **Dockerfile** file it is using **envoyproxy/envoy:866a4bab8c1e7809e26409ac9636843070b2f61c** as a base image which is not available for arm64 so replaced it with **envoyproxy/envoy:v1.17-latest** image.

In **deploycontainer.sh** file modified the code to build and upload image to dockerhub.